### PR TITLE
Reject new updates detected with Cruft

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,14 @@
 {
   "template": "https://github.com/vshn/appcat-cookiecutter",
-  "commit": "bab9c85e9d17274dbc753343111f49e08be2c502",
+  "commit": "4f8ece84d5572798ab72cfa05bb5b38a6103f3c8",
   "checkout": null,
   "context": {
     "cookiecutter": {
       "app_name": "appcat",
       "component_repo": "kidswiss/component-appcat",
       "_copy_without_render": [
-        ".github/workflows/cruft-update.yml"
+        ".github/workflows/cruft-update.yml",
+        ".github/changelog-configuration.json"
       ],
       "_template": "https://github.com/vshn/appcat-cookiecutter"
     }


### PR DESCRIPTION
This is an autogenerated PR. Use this to reject the changes in this repository.

[Cruft](https://cruft.github.io/cruft/) has detected updates from the Cookiecutter repository.